### PR TITLE
Minor fix to setup.sql so it knows what database to create the table in

### DIFF
--- a/backend/src/setup.sql
+++ b/backend/src/setup.sql
@@ -2,6 +2,8 @@ DROP DATABASE IF EXISTS database;
 
 CREATE DATABASE database;
 
+\c database;
+
 DROP TABLE IF EXISTS users;
 
 CREATE TABLE users (


### PR DESCRIPTION
`## 📌 Description
Minor fix to setup.sql to let it know what database to create the new table in.
Allows our team members who don't yet have the database on their machines to successfully run psql -U postgres -f src/setup.sql

## ✅ Checklist
- [ ✅] My code follows the style guidelines of this project.
- [ ✅] I have performed a self-review of my code.
- [✅ ] I have added tests that prove my fix is effective or that my feature works.
- [✅ ] I have reviewed the Git Workflow document for our team.


## ⚠️ Important: Merge into `dev`
- Base branch should be `dev` — **Do NOT merge directly into `main`.**
- Only `dev` merges into `main` for releases at the end of the Sprint.